### PR TITLE
Add Gson Data Class reflective test

### DIFF
--- a/src/jmh/java/com/example/SpeedTest.java
+++ b/src/jmh/java/com/example/SpeedTest.java
@@ -8,6 +8,7 @@ import com.esotericsoftware.kryo.serializers.CompatibleFieldSerializer;
 import com.example.adapter.GeneratedJsonAdapterFactory;
 import com.example.adapter.GeneratedTypeAdapterFactory;
 import com.example.kotlinx_serialization.Response;
+import com.example.model_dc.ResponseDC;
 import com.example.model_av.ResponseAV;
 import com.example.moshiKotlinCodegen.KCGResponse;
 import com.example.moshiKotlinReflective.KRResponse;
@@ -89,6 +90,23 @@ public class SpeedTest {
         public Gson gson;
         public String json;
         public Response response;
+    }
+
+    @State(Scope.Benchmark)
+    public static class ReflectiveDataClassGson {
+
+        @Setup
+        public void setupTrial() throws Exception {
+            gson = new GsonBuilder().create();
+            URL url = Resources.getResource("largesample.json");
+            json = Resources.toString(url, Charsets.UTF_8);
+            responseDC = gson
+                .fromJson(json, ResponseDC.class);
+        }
+
+        public Gson gson;
+        public String json;
+        public ResponseDC responseDC;
     }
 
     @State(Scope.Benchmark)
@@ -415,6 +433,13 @@ public class SpeedTest {
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.SECONDS)
+    public String gson_data_class_reflective_string_toJson(ReflectiveDataClassGson param) throws IOException {
+        return param.gson.toJson(param.responseDC);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
     public String gson_autovalue_string_toJson(AVGson param) throws IOException {
         return param.gson.toJson(param.response);
     }
@@ -541,6 +566,13 @@ public class SpeedTest {
     @OutputTimeUnit(TimeUnit.SECONDS)
     public Response gson_reflective_string_fromJson(ReflectiveGson param) throws IOException {
         return param.gson.fromJson(param.json, Response.class);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public ResponseDC gson_data_class_reflective_string_fromJson(ReflectiveGson param) throws IOException {
+        return param.gson.fromJson(param.json, ResponseDC.class);
     }
 
     @Benchmark

--- a/src/main/java/com/example/model_dc/FriendDC.kt
+++ b/src/main/java/com/example/model_dc/FriendDC.kt
@@ -1,0 +1,6 @@
+package com.example.model_dc
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FriendDC(val id: Int, val name: String?)

--- a/src/main/java/com/example/model_dc/ImageDC.kt
+++ b/src/main/java/com/example/model_dc/ImageDC.kt
@@ -1,0 +1,6 @@
+package com.example.model_dc
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ImageDC(val id: String?, val format: String?, val url: String?, val description: String?)

--- a/src/main/java/com/example/model_dc/NameDC.kt
+++ b/src/main/java/com/example/model_dc/NameDC.kt
@@ -1,0 +1,6 @@
+package com.example.model_dc
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NameDC(val first: String?, val last: String?)

--- a/src/main/java/com/example/model_dc/ResponseDC.kt
+++ b/src/main/java/com/example/model_dc/ResponseDC.kt
@@ -1,0 +1,15 @@
+package com.example.model_dc
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseDC(
+    val users: List<UserDC>?,
+    val status: String?,
+    @SerialName("is_real_json")
+    @SerializedName("is_real_json")
+    // Annotation needed for GSON @Json(name = "is_real_json")
+    val isRealJson: Boolean
+)

--- a/src/main/java/com/example/model_dc/UserDC.kt
+++ b/src/main/java/com/example/model_dc/UserDC.kt
@@ -1,0 +1,56 @@
+package com.example.model_dc
+
+import com.google.gson.annotations.SerializedName
+import com.squareup.moshi.Json
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserDC(
+    @SerialName("_id")
+    @SerializedName("_id") // Annotation needed for GSON
+    @Json(name = "_id")
+    val id: String?,
+
+    val index: Int,
+    val guid: String?,
+
+    @SerialName("is_active")
+    @SerializedName("is_active") // Annotation needed for GSON
+    @Json(name = "is_active")
+    val isActive: Boolean,
+
+    val balance: String?,
+
+    @SerialName("picture")
+    @SerializedName("picture") // Annotation needed for GSON
+    @Json(name = "picture")
+    val pictureUrl: String?,
+
+    val age: Int,
+    val name: NameDC?,
+    val company: String?,
+    val email: String?,
+    val address: String?,
+    val about: String?,
+    val registered: String?,
+    val latitude: Double,
+    val longitude: Double?,
+    val tags: List<String>?,
+    val range: List<Int>?,
+    val friends: List<FriendDC>?,
+    val images: List<ImageDC>?,
+    val greeting: String?,
+
+    @SerialName("favorite_fruit")
+    @SerializedName("favorite_fruit") // Annotation needed for GSON
+    @Json(name = "favorite_fruit")
+    val favoriteFruit: String?,
+
+    @SerialName("eye_color")
+    @SerializedName("eye_color") // Annotation needed for GSON
+    @Json(name = "eye_color")
+    val eyeColor: String?,
+
+    val phone: String?
+)


### PR DESCRIPTION
Following the suggestion by [allidoiswarren](https://github.com/hzsweers/json-serialization-benchmarking/pull/4#issuecomment-394771827), this PR adds Gson reflective tests for the model converted to Kotlin data classes.

Here are the results in my local machine:

```
# Run complete. Total time: 03:51:53

Benchmark                                                    Mode  Cnt     Score    Error  Units
SpeedTest.gson_autovalue_buffer_fromJson                    thrpt  200  1095.563 ±  6.812  ops/s
SpeedTest.gson_autovalue_buffer_fromJson_minified           thrpt  200  1234.639 ±  5.813  ops/s
SpeedTest.gson_autovalue_buffer_toJson                      thrpt  200   502.326 ± 14.255  ops/s
SpeedTest.gson_autovalue_string_fromJson                    thrpt  200  1170.958 ± 16.552  ops/s
SpeedTest.gson_autovalue_string_fromJson_minified           thrpt  200  1305.224 ± 18.794  ops/s
SpeedTest.gson_autovalue_string_toJson                      thrpt  200  1037.069 ± 16.403  ops/s

SpeedTest.gson_reflective_string_fromJson                   thrpt  200  1262.556 ±  8.262  ops/s
SpeedTest.gson_data_class_reflective_string_fromJson        thrpt  200  1213.937 ±  8.261  ops/s

SpeedTest.gson_reflective_string_toJson                     thrpt  200   764.524 ± 19.707  ops/s
SpeedTest.gson_data_class_reflective_string_toJson          thrpt  200   710.050 ± 10.498  ops/s

SpeedTest.kryo_fromBytes                                    thrpt  200  1122.079 ± 22.177  ops/s
SpeedTest.kryo_toBytes                                      thrpt  200   795.754 ± 13.732  ops/s
SpeedTest.kserializer_string_fromJson                       thrpt  200  1098.361 ±  9.070  ops/s
SpeedTest.kserializer_string_fromJson_minified              thrpt  200  1048.162 ± 72.512  ops/s
SpeedTest.kserializer_string_toJson                         thrpt  200  1120.391 ±  6.272  ops/s
SpeedTest.moshi_autovalue_buffer_fromJson                   thrpt  200   848.251 ±  3.713  ops/s
SpeedTest.moshi_autovalue_buffer_fromJson_minified          thrpt  200  1163.019 ±  6.948  ops/s
SpeedTest.moshi_autovalue_buffer_toJson                     thrpt  200  1424.148 ±  7.086  ops/s
SpeedTest.moshi_autovalue_string_fromJson                   thrpt  200   756.598 ±  6.624  ops/s
SpeedTest.moshi_autovalue_string_fromJson_minified          thrpt  200  1025.194 ±  7.660  ops/s
SpeedTest.moshi_autovalue_string_toJson                     thrpt  200  1210.602 ±  5.681  ops/s
SpeedTest.moshi_kotlin_codegen_buffer_fromJson              thrpt  200   827.530 ±  4.237  ops/s
SpeedTest.moshi_kotlin_codegen_buffer_fromJson_minified     thrpt  200  1130.581 ±  5.764  ops/s
SpeedTest.moshi_kotlin_codegen_buffer_toJson                thrpt  200  1454.202 ±  8.589  ops/s
SpeedTest.moshi_kotlin_codegen_string_fromJson              thrpt  200   735.561 ±  7.342  ops/s
SpeedTest.moshi_kotlin_codegen_string_fromJson_minified     thrpt  200   984.222 ±  8.178  ops/s
SpeedTest.moshi_kotlin_codegen_string_toJson                thrpt  200  1192.456 ± 19.526  ops/s
SpeedTest.moshi_kotlin_reflective_buffer_fromJson           thrpt  200   767.816 ±  3.474  ops/s
SpeedTest.moshi_kotlin_reflective_buffer_fromJson_minified  thrpt  200   996.405 ±  4.826  ops/s
SpeedTest.moshi_kotlin_reflective_buffer_toJson             thrpt  200  1186.828 ±  5.831  ops/s
SpeedTest.moshi_kotlin_reflective_string_fromJson           thrpt  200   663.877 ±  2.297  ops/s
SpeedTest.moshi_kotlin_reflective_string_toJson             thrpt  200  1055.238 ±  6.157  ops/s
SpeedTest.moshi_reflective_string_fromJson                  thrpt  200   704.847 ±  4.864  ops/s
SpeedTest.moshi_reflective_string_toJson                    thrpt  200  1206.751 ±  4.943  ops/s
```

The data class parsing is slightly less performant but not by much. 