### PR TITLE
Enable legacy storage

### DIFF
--- a/android/benchmark/src/androidTest/AndroidManifest.xml
+++ b/android/benchmark/src/androidTest/AndroidManifest.xml
@@ -22,6 +22,7 @@
 
   <application
       android:debuggable="false"
+      android:requestLegacyExternalStorage="true"
       tools:ignore="HardcodedDebugMode"
       tools:replace="android:debuggable"/>
 </manifest>


### PR DESCRIPTION
@ZacSweers this flag in the manifest is required to enable report generation on AGP 3.5, as it depends on legacy external storage behavior.