### PR TITLE
Migrated kotlinx.serialization to 1.0.0 and Kotlin to 1.4.10

### DIFF
--- a/android/benchmark/build.gradle
+++ b/android/benchmark/build.gradle
@@ -36,7 +36,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 dependencies {
   androidTestImplementation "com.google.guava:guava:27.1-jre"
   androidTestImplementation "com.squareup.okio:okio:2.4.3"
-  androidTestImplementation "androidx.benchmark:benchmark-junit4:1.1.0-SNAPSHOT"
+  androidTestImplementation "androidx.benchmark:benchmark-junit4:1.0.0"
   androidTestImplementation "junit:junit:4.12"
   androidTestImplementation "androidx.test:runner:1.2.0"
   androidTestImplementation "androidx.test:rules:1.2.0"

--- a/android/benchmark/src/androidTest/kotlin/dev/zacsweers/jsonserialization/android/AndroidBenchmark.kt
+++ b/android/benchmark/src/androidTest/kotlin/dev/zacsweers/jsonserialization/android/AndroidBenchmark.kt
@@ -33,7 +33,6 @@ import dev.zacsweers.jsonserialization.models.java_serialization.ResponseJ
 import dev.zacsweers.jsonserialization.models.model_av.ResponseAV
 import dev.zacsweers.jsonserialization.models.moshiKotlinCodegen.KCGResponse
 import dev.zacsweers.jsonserialization.models.moshiKotlinReflective.KRResponse
-import kotlinx.serialization.ImplicitReflectionSerializer
 import kotlinx.serialization.KSerializer
 import okio.Buffer
 import okio.BufferedSink
@@ -48,7 +47,6 @@ import java.io.OutputStreamWriter
 import java.io.Reader
 import java.io.Writer
 
-@ImplicitReflectionSerializer
 @LargeTest
 @RunWith(Parameterized::class)
 class AndroidBenchmark(

--- a/android/benchmark/src/androidTest/kotlin/dev/zacsweers/jsonserialization/android/AndroidPolymorphicBenchmark.kt
+++ b/android/benchmark/src/androidTest/kotlin/dev/zacsweers/jsonserialization/android/AndroidPolymorphicBenchmark.kt
@@ -17,7 +17,6 @@ import dev.zacsweers.jsonserialization.models.model_av.AbstractResponseAV
 import dev.zacsweers.jsonserialization.models.model_av.ResponseAV
 import dev.zacsweers.jsonserialization.models.moshiKotlinCodegen.KCGAbstractResponse
 import dev.zacsweers.jsonserialization.models.moshiKotlinCodegen.KCGResponse
-import kotlinx.serialization.ImplicitReflectionSerializer
 import okio.Buffer
 import okio.BufferedSink
 import okio.BufferedSource
@@ -31,7 +30,6 @@ import java.io.OutputStreamWriter
 import java.io.Reader
 import java.io.Writer
 
-@ImplicitReflectionSerializer
 @LargeTest
 @RunWith(Parameterized::class)
 class AndroidPolymorphicBenchmark(

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
-ext.kotlin_version = '1.3.61'
-ext.serialization_version = '0.14.0'
+ext.kotlin_version = '1.4.10'
+ext.serialization_version = '1.0.0'
 ext.jmh_version = '1.22'
 
 buildscript {
-    ext.kotlin_version = '1.3.61'
-    ext.serialization_version = '0.14.0'
+    ext.kotlin_version = '1.4.10'
+    ext.serialization_version = '1.0.0'
     ext.jmh_version = '1.22'
     repositories {
         google()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     api 'com.google.code.gson:gson:2.8.6'
     api "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     api "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    api "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
+    api "org.jetbrains.kotlinx:kotlinx-serialization-json:$serialization_version"
 }

--- a/models/src/main/java/dev/zacsweers/jsonserialization/models/kotlinx_serialization/Response.kt
+++ b/models/src/main/java/dev/zacsweers/jsonserialization/models/kotlinx_serialization/Response.kt
@@ -2,14 +2,10 @@ package dev.zacsweers.jsonserialization.models.kotlinx_serialization
 
 import com.google.gson.annotations.SerializedName
 import com.squareup.moshi.Json
-import kotlinx.serialization.ImplicitReflectionSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UnstableDefault
 
-@UseExperimental(UnstableDefault::class)
-@ImplicitReflectionSerializer
 @Serializable
 class Response {
 
@@ -23,13 +19,13 @@ class Response {
     var isRealJson: Boolean = false
 
     fun stringify(serializer: KSerializer<Response>): String {
-        return kotlinx.serialization.json.Json.stringify(serializer, this)
+        return kotlinx.serialization.json.Json.encodeToString(serializer, this)
     }
 
     companion object {
         @JvmStatic
         fun parse(serializer: KSerializer<Response>, str: String): Response {
-            return kotlinx.serialization.json.Json.parse(serializer, str)
+            return kotlinx.serialization.json.Json.decodeFromString(serializer, str)
         }
 
         @JvmStatic


### PR DESCRIPTION
This PR updates `kotlinx.serizalization` to its first stable version - `1.0.0` :tada:

In order to achieve it, Kotlin version was bumped to `1.4.10` and some small code changes were made to remove deprecated parts.

I'm not sure if you want to rerun the benchmark on your own device @ZacSweers, my results of `./gradlew :android:benchmark:connectedCheck` are available below.

Cheers!

Results for device **Samsung Galaxy S7 Edge**, Android 8, `SM_G935F`

name | time
-- | --
gson_fromJson[minified=false,typeKeyLocation=first] | 2,59
kserializer_string_fromJson[minified=false] | 2,82
moshi_kotlin_codegen_string_toJson[minified=false] | 4,43
moshi_reflective_string_fromJson[minified=true] | 4,66
moshi_autovalue_string_toJson[minified=false] | 5,42
gson_fromJson[minified=true,typeKeyLocation=last] | 5,54
moshi_reflective_string_toJson[minified=false] | 6,31
gson_autovalue_string_toJson[minified=false] | 6,65
moshi_fromJson[minified=true,typeKeyLocation=first] | 7,98
moshi_autovalue_string_fromJson[minified=true] | 8,00
gson_autovalue_string_fromJson[minified=true] | 8,83
moshi_kotlin_codegen_string_toJson[minified=true] | 8,93
moshi_autovalue_buffer_toJson[minified=true] | 8,93
moshi_autovalue_buffer_fromJson[minified=true] | 8,98
moshi_kotlin_codegen_string_fromJson[minified=true] | 8,99
gson_autovalue_string_toJson[minified=true] | 9,01
gson_autovalue_buffer_fromJson[minified=true] | 9,03
moshi_autovalue_buffer_toJson[minified=false] | 9,05
moshi_kotlin_codegen_buffer_fromJson[minified=true] | 9,05
gson_autovalue_buffer_fromJson[minified=false] | 9,07
moshi_reflective_string_toJson[minified=true] | 9,11
moshi_toJson[minified=false,typeKeyLocation=first] | 9,14
moshi_kotlin_codegen_buffer_fromJson[minified=false] | 9,18
moshi_autovalue_buffer_fromJson[minified=false] | 9,18
moshi_kotlin_codegen_string_fromJson[minified=false] | 9,22
gson_reflective_string_fromJson[minified=false] | 9,25
kserializer_string_toJson[minified=false] | 9,27
moshi_autovalue_string_fromJson[minified=false] | 9,30
moshi_kotlin_reflective_string_toJson[minified=true] | 9,33
moshi_kotlin_reflective_buffer_toJson[minified=true] | 9,34
moshi_fromJson[minified=false,typeKeyLocation=first] | 9,34
moshi_kotlin_reflective_string_fromJson[minified=true] | 9,34
moshi_reflective_string_fromJson[minified=false] | 9,39
moshi_fromJson[minified=true,typeKeyLocation=last] | 9,43
gson_fromJson[minified=true,typeKeyLocation=first] | 9,43
moshi_kotlin_reflective_buffer_fromJson[minified=true] | 9,49
moshi_kotlin_reflective_string_toJson[minified=false] | 9,51
moshi_kotlin_reflective_string_fromJson[minified=false] | 9,52
gson_fromJson[minified=false,typeKeyLocation=last] | 9,55
moshi_kotlin_reflective_buffer_fromJson[minified=false] | 9,64
moshi_fromJson[minified=false,typeKeyLocation=last] | 9,86
gson_autovalue_buffer_toJson[minified=true] | 16,43
gson_toJson[minified=false,typeKeyLocation=last] | 16,79
gson_toJson[minified=true,typeKeyLocation=first] | 16,82
gson_toJson[minified=true,typeKeyLocation=last] | 16,99
moshi_autovalue_string_toJson[minified=true] | 99,96
kserializer_string_fromJson[minified=true] | 100,05
moshi_kotlin_codegen_buffer_toJson[minified=false] | 100,28
kserializer_string_toJson[minified=true] | 100,56
gson_reflective_string_toJson[minified=true] | 100,69
gson_toJson[minified=false,typeKeyLocation=first] | 116,96
moshi_kotlin_codegen_buffer_toJson[minified=true] | 191,02
gson_autovalue_string_fromJson[minified=false] | 191,31
moshi_toJson[minified=true,typeKeyLocation=first] | 191,57
moshi_toJson[minified=true,typeKeyLocation=last] | 191,73
gson_reflective_string_toJson[minified=false] | 192,18
moshi_toJson[minified=false,typeKeyLocation=last] | 192,31
moshi_kotlin_reflective_buffer_toJson[minified=false] | 192,98
gson_reflective_string_fromJson[minified=true] | 193,94
gson_autovalue_buffer_toJson[minified=false] | 213,49


